### PR TITLE
j293: fix incorrect descriptions

### DIFF
--- a/firs/j293/mic.json
+++ b/firs/j293/mic.json
@@ -1,6 +1,6 @@
 {
-    "node.description": "MacBook Air J293 Microphone",
-    "media.name": "MacBook Air J293 Microphone",
+    "node.description": "MacBook Pro J293 Microphone",
+    "media.name": "MacBook Pro J293 Microphone",
     "filter.graph": {
         "nodes": [
             {


### PR DESCRIPTION
I tried installing this WIP patch on my M1 MacBook Pro, but couldn't get it to work after doing `sudo make install` and restarting pipewire/wireplumber. However, I did notice you errantly put this as J293 MacBook Air instead of J293 MacBook Pro, so here's a simple patch for that.